### PR TITLE
Filtered out new filters added by Contentful

### DIFF
--- a/cer-graphql/index.js
+++ b/cer-graphql/index.js
@@ -88,6 +88,7 @@ async function createServer(config) {
     // Get a list of the types that have the ssoProtected field
     let protectedTypes = Object.keys(contentfulSchema._typeMap)
         .filter(x => x.includes('Filter')) // Get all the filters
+        .filter(x => !x.startsWith('cf')) // Filter out Contentful's special cf* filters
         .filter(y => contentfulSchema._typeMap[y]._fields.ssoProtected) // Filter by those with an ssoProtected field
         .flatMap(z => [z.replace('Filter', ''), z.replace('Filter', 'Collection')]) // Replace 'xfilter' with 'x' and 'xCollection'
         .map(a => a[0].toLowerCase() + a.substring(1)); // Make first char lower case
@@ -212,6 +213,7 @@ async function createServer(config) {
         resolvers: [{ Query: customQueryResolvers }],
     });
 
+
     return new ApolloServer({
         schema,
         context: ({ req }) => {
@@ -267,12 +269,13 @@ if (require.main === module) {
             process.exit(1);
         }
 
-        let server = await createServer(config);
-
-        // The 'listen' method launches a web server.
-        server.listen().then(({ url }) => {
-            console.log(`🚀  Content API server ready at ${url}. Server started in: ${new Date().getTime() - startTime}ms.`);
-        });
+        try {
+            let server = await createServer(config);
+            // The 'listen' method launches a web server.
+            server.listen().then(({ url }) => {
+                console.log(`🚀  Content API server ready at ${url}. Server started in: ${new Date().getTime() - startTime}ms.`);
+            });
+        } catch(error) { console.log('Error creating server object and getting it to listen: ', error) }
     })();
 }
 

--- a/cer-graphql/index.js
+++ b/cer-graphql/index.js
@@ -213,7 +213,6 @@ async function createServer(config) {
         resolvers: [{ Query: customQueryResolvers }],
     });
 
-
     return new ApolloServer({
         schema,
         context: ({ req }) => {
@@ -271,6 +270,7 @@ if (require.main === module) {
 
         try {
             let server = await createServer(config);
+
             // The 'listen' method launches a web server.
             server.listen().then(({ url }) => {
                 console.log(`🚀  Content API server ready at ${url}. Server started in: ${new Date().getTime() - startTime}ms.`);


### PR DESCRIPTION
# Filtered out new filters added by Contentful
* Contentful has added some extra GraphQL filters which the existing logic was incorrectly interpreting as `protectedTypes`, and attempting to generate resolvers for (even though there is no corresponding GraphQL `type`. This was generating errors when the server object was being created.

These Contentful filters have been filtered out from the protected types with the line:

```js
        .filter(x => !x.startsWith('cf')) // Filter out Contentful's special cf* filters
```

## Other Changes
* Moved create server and listen code into try/catch to generate appropriate error messages

## Checklist
- [x] All tests passed
- [x] Deployed successfully to `sandbox`