### PR TITLE
Icon URLs in Search Results

### DIFF
--- a/hub-search-proxy/env/dev.json
+++ b/hub-search-proxy/env/dev.json
@@ -7,7 +7,8 @@
     "ELASTICSEARCH_ENDPOINT": "${ssm:/dev/research-hub/elasticsearch_endpoint~true}",
     "CORS_ACCESS_CONTROL_ALLOW_ORIGINS": "*",
     "CONTENTFUL_SPACE_ID": "${ssm:/dev/research-hub/contentful-space-id~true}",
-    "CONTENTFUL_ACCESS_TOKEN": "${ssm:/dev/research-hub/contentful-mgmt-access-token~true}",
+    "CONTENTFUL_MGMT_ACCESS_TOKEN": "${ssm:/dev/research-hub/contentful-mgmt-access-token~true}",
+    "CONTENTFUL_ACCESS_TOKEN": "${ssm:/dev/research-hub/contentful-access-token~true}",
     "resourceKey": "3cf7aeb4-ad8c-4505-a8e3-7d2a556e188d",
     "PROFILE": "uoa-sandbox"
 }

--- a/hub-search-proxy/env/prod.json
+++ b/hub-search-proxy/env/prod.json
@@ -7,7 +7,8 @@
     "ELASTICSEARCH_ENDPOINT": "TBD - add endpoint to parameter store",
     "CORS_ACCESS_CONTROL_ALLOW_ORIGINS": "https://research-hub.auckland.ac.nz",
     "CONTENTFUL_SPACE_ID": "${ssm:/prod/research-hub/contentful-space-id~true}",
-    "CONTENTFUL_ACCESS_TOKEN": "${ssm:/prod/research-hub/contentful-mgmt-access-token~true}",
+    "CONTENTFUL_MGMT_ACCESS_TOKEN": "${ssm:/prod/research-hub/contentful-mgmt-access-token~true}",
+    "CONTENTFUL_ACCESS_TOKEN": "${ssm:/prod/research-hub/contentful-access-token~true}",
     "resourceKey": "180f8f50-c1f3-4b9a-b793-0fca514ab708",
     "PROFILE": "uoa-its-prod"
 }

--- a/hub-search-proxy/env/test.json
+++ b/hub-search-proxy/env/test.json
@@ -7,7 +7,8 @@
     "ELASTICSEARCH_ENDPOINT": "${ssm:/test/research-hub/elasticsearch_endpoint~true}",
     "CORS_ACCESS_CONTROL_ALLOW_ORIGINS": "*",
     "CONTENTFUL_SPACE_ID": "${ssm:/test/research-hub/contentful-space-id~true}",
-    "CONTENTFUL_ACCESS_TOKEN": "${ssm:/test/research-hub/contentful-mgmt-access-token~true}",
+    "CONTENTFUL_MGMT_ACCESS_TOKEN": "${ssm:/test/research-hub/contentful-mgmt-access-token~true}",
+    "CONTENTFUL_ACCESS_TOKEN": "${ssm:/test/research-hub/contentful-access-token~true}",
     "resourceKey": "891f7417-3a6e-4152-b6d5-c37433acae54",
     "PROFILE": "uoa-its-nonprod"
 }

--- a/hub-search-proxy/handler.js
+++ b/hub-search-proxy/handler.js
@@ -3,10 +3,18 @@ const { Client } = require('@elastic/elasticsearch');
 const AWS = require('aws-sdk');
 const createAwsElasticsearchConnector = require('aws-elasticsearch-connector');
 const contentfulExport = require('contentful-export');
+const contentful = require('contentful')
 
-const token = process.env.CONTENTFUL_ACCESS_TOKEN;
+
+const mgmtToken = process.env.CONTENTFUL_MGMT_ACCESS_TOKEN;  // Contentful Management API Token
+const token = process.env.CONTENTFUL_ACCESS_TOKEN;  // Contentful Delivery API Token
 const spaceId = process.env.CONTENTFUL_SPACE_ID;
 const region = 'ap-southeast-2';
+
+const deliveryApiClient = contentful.createClient({
+  space: spaceId,
+  accessToken: token
+})
 
 let credentials;
 try {
@@ -94,6 +102,7 @@ module.exports.search = async (event, context) => {
             "fields.ssoProtected",
             "fields.searchable",
             "fields.keywords",
+            "fields.icon",
             "sys.contentType"
           ]
         },
@@ -147,6 +156,7 @@ module.exports.search = async (event, context) => {
             "fields.ssoProtected",
             "fields.searchable",
             "fields.keywords",
+            "fields.icon",
             "sys.contentType"
           ]
         },
@@ -227,6 +237,7 @@ module.exports.search = async (event, context) => {
             "fields.ssoProtected",
             "fields.searchable",
             "fields.keywords",
+            "fields.icon",
             "sys.contentType"
           ]
         },
@@ -281,6 +292,12 @@ module.exports.search = async (event, context) => {
 
 module.exports.update = async (event, context) => {
   let doc = JSON.parse(event.body);
+
+  // add icon url
+  if (doc.fields.hasOwnProperty('icon')) {
+    const iconUrl = await getIconUrl(doc.fields.icon['en-US'].sys.id);
+    doc.fields.icon['en-US']['url'] = iconUrl;
+  }
 
   const params = {
     id: event.pathParameters.id,
@@ -349,7 +366,7 @@ module.exports.bulk = async () => {
     console.log('Exporting data from Contentful space id: ' + spaceId);
     const options = {
       spaceId: spaceId,
-      managementToken: token,
+      managementToken: mgmtToken,
       contentOnly: true,
       downloadAssets: false,
       saveFile: false
@@ -360,6 +377,14 @@ module.exports.bulk = async () => {
     );
 
     console.log(`Found ${validEntries.length} entries to upload.`);
+
+    // add icon urls
+    for(var i = 0; i < validEntries.length; i++) {
+      if (validEntries[i].fields.hasOwnProperty('icon')) {
+        const iconUrl = await getIconUrl(validEntries[i].fields.icon['en-US'].sys.id);
+        validEntries[i].fields.icon['en-US']['url'] = iconUrl;
+      }
+    };
 
     // perform the upload
     console.log(`Uploading documents to index: ${ELASTICSEARCH_INDEX_NAME}`);
@@ -418,5 +443,14 @@ function formatResponse(status, body) {
           "Access-Control-Allow-Origin": process.env.CORS_ACCESS_CONTROL_ALLOW_ORIGINS,
           "Content-Type": "application/json"
       }
+  }
+}
+
+async function getIconUrl (iconId) {
+  try {
+    const asset = await deliveryApiClient.getAsset(iconId);
+    return asset.fields.file.url
+  } catch(error) {
+    console.log(error);
   }
 }

--- a/hub-search-proxy/package-lock.json
+++ b/hub-search-proxy/package-lock.json
@@ -11,6 +11,7 @@
         "@elastic/elasticsearch": "^7.11.0",
         "aws-elasticsearch-connector": "^9.0.3",
         "aws-sdk": "^2.841.0",
+        "contentful": "^8.2.0",
         "contentful-export": "^7.11.7"
       },
       "devDependencies": {
@@ -1161,11 +1162,11 @@
       }
     },
     "node_modules/contentful": {
-      "version": "8.1.7",
-      "resolved": "https://registry.npmjs.org/contentful/-/contentful-8.1.7.tgz",
-      "integrity": "sha512-dFlpRjkrTp+TG6kCjERIgzsBRTfjflRnjosE0uQus7dENrz2nrVEYhFO/T3WrKQfAbTyozKcTpWr5pEZiXpm2A==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/contentful/-/contentful-8.2.0.tgz",
+      "integrity": "sha512-q/4HZZUI1fT3QBnPMUP/FQromfbuNwggS3RQZjTzYj6bU6M5xamuuPWrYcrOhhuG06ii8HopsYbV/K4E13jGig==",
       "dependencies": {
-        "axios": "^0.21.0",
+        "axios": "^0.21.1",
         "contentful-resolve-response": "^1.3.0",
         "contentful-sdk-core": "^6.5.0",
         "fast-copy": "^2.1.0",
@@ -6448,11 +6449,11 @@
       }
     },
     "contentful": {
-      "version": "8.1.7",
-      "resolved": "https://registry.npmjs.org/contentful/-/contentful-8.1.7.tgz",
-      "integrity": "sha512-dFlpRjkrTp+TG6kCjERIgzsBRTfjflRnjosE0uQus7dENrz2nrVEYhFO/T3WrKQfAbTyozKcTpWr5pEZiXpm2A==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/contentful/-/contentful-8.2.0.tgz",
+      "integrity": "sha512-q/4HZZUI1fT3QBnPMUP/FQromfbuNwggS3RQZjTzYj6bU6M5xamuuPWrYcrOhhuG06ii8HopsYbV/K4E13jGig==",
       "requires": {
-        "axios": "^0.21.0",
+        "axios": "^0.21.1",
         "contentful-resolve-response": "^1.3.0",
         "contentful-sdk-core": "^6.5.0",
         "fast-copy": "^2.1.0",

--- a/hub-search-proxy/package.json
+++ b/hub-search-proxy/package.json
@@ -28,6 +28,7 @@
     "@elastic/elasticsearch": "^7.11.0",
     "aws-elasticsearch-connector": "^9.0.3",
     "aws-sdk": "^2.841.0",
+    "contentful": "^8.2.0",
     "contentful-export": "^7.11.7"
   }
 }

--- a/hub-search-proxy/serverless.yml
+++ b/hub-search-proxy/serverless.yml
@@ -46,6 +46,7 @@ provider:
     ELASTICSEARCH_ENDPOINT: ${file(env/${self:provider.stage}.json):ELASTICSEARCH_ENDPOINT}
     CORS_ACCESS_CONTROL_ALLOW_ORIGINS: ${file(env/${self:provider.stage}.json):CORS_ACCESS_CONTROL_ALLOW_ORIGINS}
     CONTENTFUL_SPACE_ID: ${file(env/${self:provider.stage}.json):CONTENTFUL_SPACE_ID}
+    CONTENTFUL_MGMT_ACCESS_TOKEN: ${file(env/${self:provider.stage}.json):CONTENTFUL_MGMT_ACCESS_TOKEN}
     CONTENTFUL_ACCESS_TOKEN: ${file(env/${self:provider.stage}.json):CONTENTFUL_ACCESS_TOKEN}
     PROFILE: ${file(env/${self:provider.stage}.json):PROFILE}
   apiGateway:


### PR DESCRIPTION
Bulk upload and update lambdas now fetch icon urls for content with icons (previously only the icon id was present). This makes rendering search results in the front end more efficient.