### PR TITLE
enable gzip

### DIFF
--- a/terraform/main-website-cloudfront.tf
+++ b/terraform/main-website-cloudfront.tf
@@ -33,6 +33,9 @@ resource "aws_cloudfront_distribution" "main_website" {
     allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
     cached_methods   = ["GET", "HEAD"]
     target_origin_id = var.dns_entry
+    
+    # support gzip and other http transfer compression
+    compress         = true
 
     forwarded_values {
       query_string = true


### PR DESCRIPTION
Small change to add `compression` option in Terraform. This enables gzip transfer compression on AWS Cloudfront. Deployed to Test and verified the change works.