### PR TITLE
Fix persistent banner image 

### DIFF
--- a/research-hub-web/src/app/components/articles/articles.component.ts
+++ b/research-hub-web/src/app/components/articles/articles.component.ts
@@ -115,6 +115,8 @@ export class ArticlesComponent implements OnInit, OnDestroy {
         // Set banner image URL for webp format if webp is supported
         if (data.banner?.url) {
           this.bannerImageUrl = this.supportsWebp ? data.banner?.url + '?w=1900&fm=webp' : data.banner?.url + '?w=1900';
+        } else {
+          this.bannerImageUrl = undefined;
         }
 
         this.bodyMediaService.setBodyMedia(data.bodyText?.links);

--- a/research-hub-web/src/app/components/case-study/case-study.component.ts
+++ b/research-hub-web/src/app/components/case-study/case-study.component.ts
@@ -117,6 +117,8 @@ export class CaseStudyComponent implements OnInit, OnDestroy {
         // Set banner image URL for webp format if webp is supported
         if (data.banner?.url) {
           this.bannerImageUrl = this.supportsWebp ? data.banner?.url + '?w=1900&fm=webp' : data.banner?.url + '?w=1900';
+        } else {
+          this.bannerImageUrl = undefined;
         }
 
         this.bodyMediaService.setBodyMedia(data.bodyText.links);

--- a/research-hub-web/src/app/components/equipments/equipment.component.ts
+++ b/research-hub-web/src/app/components/equipments/equipment.component.ts
@@ -111,6 +111,8 @@ export class EquipmentComponent implements OnInit, OnDestroy {
         // Set banner image URL for webp format if webp is supported
         if (data.banner?.url) {
           this.bannerImageUrl = this.supportsWebp ? data.banner?.url + '?w=1900&fm=webp' : data.banner?.url + '?w=1900';
+        } else {
+          this.bannerImageUrl = undefined;
         }
 
         this.bodyMediaService.setBodyMedia(data.bodyText?.links);

--- a/research-hub-web/src/app/components/events/events.component.ts
+++ b/research-hub-web/src/app/components/events/events.component.ts
@@ -115,6 +115,8 @@ export class EventsComponent implements OnInit, OnDestroy {
         // Set banner image URL for webp format if webp is supported
         if (data.banner?.url) {
           this.bannerImageUrl = this.supportsWebp ? data.banner?.url + '?w=1900&fm=webp' : data.banner?.url + '?w=1900';
+        } else {
+          this.bannerImageUrl = undefined;
         }
 
         this.bodyMediaService.setBodyMedia(data.bodyText?.links);

--- a/research-hub-web/src/app/components/fundings/fundings.component.ts
+++ b/research-hub-web/src/app/components/fundings/fundings.component.ts
@@ -115,6 +115,8 @@ export class FundingsComponent implements OnInit, OnDestroy {
         // Set banner image URL for webp format if webp is supported
         if (data.banner?.url) {
           this.bannerImageUrl = this.supportsWebp ? data.banner?.url + '?w=1900&fm=webp' : data.banner?.url + '?w=1900';
+        } else {
+          this.bannerImageUrl = undefined;
         }
 
         this.bodyMediaService.setBodyMedia(data.bodyText?.links);

--- a/research-hub-web/src/app/components/services/services.component.ts
+++ b/research-hub-web/src/app/components/services/services.component.ts
@@ -114,6 +114,8 @@ export class ServicesComponent implements OnInit, OnDestroy {
         // Set banner image URL for webp format if webp is supported
         if (data.banner?.url) {
           this.bannerImageUrl = this.supportsWebp ? data.banner?.url + '?w=1900&fm=webp' : data.banner?.url + '?w=1900';
+        } else {
+          this.bannerImageUrl = undefined;
         }
 
         this.bodyMediaService.setBodyMedia(data.bodyText?.links);

--- a/research-hub-web/src/app/components/softwares/softwares.component.ts
+++ b/research-hub-web/src/app/components/softwares/softwares.component.ts
@@ -108,6 +108,8 @@ export class SoftwaresComponent implements OnInit, OnDestroy {
         // Set banner image URL for webp format if webp is supported
         if (data.banner?.url) {
           this.bannerImageUrl = this.supportsWebp ? data.banner?.url + '?w=1900&fm=webp' : data.banner?.url + '?w=1900';
+        } else {
+          this.bannerImageUrl = undefined;
         }
 
         this.bodyMediaService.setBodyMedia(data.bodyText?.links);

--- a/research-hub-web/src/app/components/subhubs/subhubs.component.ts
+++ b/research-hub-web/src/app/components/subhubs/subhubs.component.ts
@@ -105,6 +105,8 @@ export class SubhubsComponent implements OnInit, OnDestroy {
         // Set banner image URL for webp format if webp is supported
         if (data.banner?.url) {
           this.bannerImageUrl = this.supportsWebp ? data.banner?.url + '?w=1900&fm=webp' : data.banner?.url + '?w=1900';
+        } else {
+          this.bannerImageUrl = undefined;
         }
       });
       this.parentSubHubs = await this.cerGraphQLService.getParentSubHubs(this.slug);


### PR DESCRIPTION
This is a fix for banner images not being reset when navigating from subhub to subhub.

The same issue does exist on all other content pages as well, so a fix has been included.