### PR TITLE
External link icon

### DIFF
--- a/research-hub-web/src/app/components/shared/cards/cards.component.html
+++ b/research-hub-web/src/app/components/shared/cards/cards.component.html
@@ -79,18 +79,18 @@
 
           <mat-card-title>
             <h4>
-              <a class="card-title" *ngIf="content.link && content.maoriName; else maoriNameNoLink" href="{{ content.link }}" target="_blank"
-                style="font-weight: lighter">{{ content['maoriName'] }}&nbsp;</a>
-              <a class="card-title" *ngIf="content.link; else noLink" href="{{ content.link }}" target="_blank">{{ content['name'] }}</a>
-              <mat-icon *ngIf="content.ssoProtected" matTooltip="SSO Login Required">&nbsp;lock</mat-icon>
+              <a class="card-title" *ngIf="content.link" href="{{ content.link }}" >
+                <span *ngIf="content.name">{{ content['name'] }}</span>
+                <span *ngIf="content.maoriName && content.name">, </span>
+                <span *ngIf="content.maoriName">{{ content['maoriName'] }}</span>
+              </a> 
+              <span class="card-title" *ngIf="!content.link" href="{{ content.link }}" >
+                <span *ngIf="content.name">{{ content['name'] }}</span>
+                <span *ngIf="content.maoriName && content.name">, </span>
+                <span *ngIf="content.maoriName">{{ content['maoriName'] }}</span>
+              </span>
             </h4>
           </mat-card-title>
-          <ng-template #maoriNameNoLink>
-            <span class="card-title" *ngIf="content.maoriName" style="font-weight: lighter">{{ content['maoriName'] }}</span>
-          </ng-template>
-          <ng-template #noLink>
-            <span class="card-title" *ngIf="content.name">{{ content['name'] }}</span>
-          </ng-template>
 
           <mat-card-content>
             <span *ngIf="content.__typename == 'Person'" class="card-summary contact-card-summary">

--- a/research-hub-web/src/styles.scss
+++ b/research-hub-web/src/styles.scss
@@ -139,6 +139,18 @@ a {
   color: $link-light-bg-color;
   font-family: $font-family;
 }
+
+// show icon for external links
+// page below is good for checking
+// http://localhost:4200/research-impact/planning-for-impact
+mat-card-title a:not([href^="/"]):after,
+ngx-contentful-rich-text mat-card-title a:not([href^="/"]):after,
+ngx-contentful-rich-text a:not([href^="/"]) .ng-star-inserted:after {
+  font-family: "Material Icons";
+  content: " \e895";
+  font-size: 0.8em;
+}
+
 span {
   font-family: $font-family;
 }


### PR DESCRIPTION
Add icons to external links (non-researchhub pages) in:
* body text
* inline cards
* side column cards

Fixed up template to handle card titles with links/no links/english/maori text - all combinations should be gracefully displayed with a comma between the two different language titles if both present.

This is a good page to check the expected behaviour.
http://localhost:4200/research-impact/planning-for-impact