### PR TITLE
Update for Terraform AWS Provider v4.0.0

### DIFF
--- a/terraform/main-website-bucket.tf
+++ b/terraform/main-website-bucket.tf
@@ -1,20 +1,5 @@
 resource "aws_s3_bucket" "main_website" {
   bucket = var.dns_entry
-  acl    = "private"
-
-  versioning {
-    enabled = false
-  }
-
-  # Encrypt the data at rest. We use the default Service Side Encryption
-  # in order to minimize issues between CloudFront and KMS
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
-    }
-  }
 
   tags = merge(
     local.common_tags,
@@ -28,6 +13,31 @@ resource "aws_s3_bucket" "main_website" {
       logging
     ]
   }
+}
+
+resource "aws_s3_bucket_versioning" "main_website_versioning" {
+  bucket = aws_s3_bucket.main_website.id
+  
+  versioning_configuration {
+    status = "Suspended"
+  }
+}
+
+# Encrypt the data at rest. We use the default Service Side Encryption
+# in order to minimize issues between CloudFront and KMS
+resource "aws_s3_bucket_server_side_encryption_configuration" "main_website_server_side_encryption" {
+  bucket = aws_s3_bucket.main_website.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_acl" "main_website_acl" {
+  bucket = aws_s3_bucket.main_website.id
+  acl    = "private"
 }
 
 resource "aws_s3_bucket_policy" "cdn_access_policy" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -5,8 +5,10 @@ terraform {
   }
 }
 
+# NOTE: aws provider v4 is the last to support Terraform v0.12-0.15, therefore we specify versions less than 5.0.0.
+# as Jenkins currently is on v0.12.31 of Terraform.
 provider "aws" {
-  version = ">= 3.41.0"
+  version = ">= 3.41.0, < 5.0.0"
   region  = var.aws_region
   profile = var.aws_profile
   ignore_tags {

--- a/terraform/secondary-website-bucket.tf
+++ b/terraform/secondary-website-bucket.tf
@@ -17,7 +17,8 @@ resource "aws_s3_bucket" "secondary_website" {
 }
 
 resource "aws_s3_bucket_versioning" "secondary_website_versioning" {
-  bucket = aws_s3_bucket.secondary_website.id
+  count  = var.create_secondary ? 1 : 0
+  bucket = aws_s3_bucket.secondary_website[count.index].id
   
   versioning_configuration {
     status = "Suspended"
@@ -27,7 +28,8 @@ resource "aws_s3_bucket_versioning" "secondary_website_versioning" {
 # Encrypt the data at rest. We use the default Service Side Encryption
 # in order to minimize issues between CloudFront and KMS
 resource "aws_s3_bucket_server_side_encryption_configuration" "secondary_website_server_side_encryption" {
-  bucket = aws_s3_bucket.secondary_website.id
+  count  = var.create_secondary ? 1 : 0
+  bucket = aws_s3_bucket.secondary_website[count.index].id
 
   rule {
     apply_server_side_encryption_by_default {
@@ -37,7 +39,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "secondary_website
 }
 
 resource "aws_s3_bucket_acl" "secondary_website_acl" {
-  bucket = aws_s3_bucket.secondary_website.id
+  count  = var.create_secondary ? 1 : 0
+  bucket = aws_s3_bucket.secondary_website[count.index].id
   acl    = "private"
 }
 


### PR DESCRIPTION
# Terraform AWS Provider Version 4.0.0

## Description
Terraform AWS Provider has upgraded to version 4.0.0, published on 10 February 2022.

Major changes in the release include:

- Version 4.0.0 of the AWS Provider introduces significant changes to the aws_s3_bucket resource.
- Version 4.0.0 of the AWS Provider will be the last major version to support EC2-Classic resources as AWS plans to fully retire EC2-Classic Networking. See the AWS News Blog for additional details.
- Version 4.0.0 and 4.x.x versions of the AWS Provider will be the last versions compatible with Terraform 0.12-0.15.

## Solution
The terraform scripts have been updated according to the [Version 4 Upgrade Guide](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade#s3-bucket-refactor).

## Screenshots
N/A

## Testing
N/A

## Have the changes been checked in the following browsers?
N/A