### PR TITLE
Spacer on 3 column layout pages

### DIFF
--- a/research-hub-web/src/app/components/articles/article/article.component.html
+++ b/research-hub-web/src/app/components/articles/article/article.component.html
@@ -104,7 +104,7 @@
           relatedDocs.length > 0 ||
           relatedContacts.length > 0 ||
           relatedOrgs.length > 0
-        "
+          ; else fillerLeft"
         fxFlex.gt-lg="0 0 auto"
         fxLayout="column"
         fxFlexOrder="1"
@@ -167,7 +167,7 @@
 
       <!-- Related items -->
       <div
-        *ngIf="relatedItems.length > 0"
+        *ngIf="relatedItems.length > 0; else fillerRight"
         fxFlex.gt-lg="0 0 auto"
         fxLayout="column"
         fxFlexOrder="3"
@@ -195,6 +195,9 @@
   </div>
 </div>
 
-<ng-template #filler>
+<ng-template #fillerLeft>
+  <div fxFlex="0 0 350px" fxFlexOrder="1" fxHide.lt-lg></div>
+</ng-template>
+<ng-template #fillerRight>
   <div fxFlex="0 0 350px" fxFlexOrder="3" fxHide.lt-lg></div>
 </ng-template>

--- a/research-hub-web/src/app/components/casestudys/case-study/case-study.component.html
+++ b/research-hub-web/src/app/components/casestudys/case-study/case-study.component.html
@@ -92,7 +92,7 @@
           relatedDocs.length > 0 ||
           relatedContacts.length > 0 ||
           relatedOrgs.length > 0
-        "
+          ; else fillerLeft"
         fxFlex.gt-lg="0 0 auto"
         fxLayout="column"
         fxFlexOrder="1"
@@ -156,7 +156,7 @@
 
       <!-- Related items -->
       <div
-        *ngIf="relatedItems.length > 0"
+        *ngIf="relatedItems.length > 0; else fillerRight"
         fxFlex.gt-lg="0 0 auto"
         fxLayout="column"
         fxFlexOrder="3"
@@ -184,6 +184,9 @@
   </div>
 </div>
 
-<ng-template #filler>
+<ng-template #fillerLeft>
+  <div fxFlex="0 0 350px" fxFlexOrder="1" fxHide.lt-lg></div>
+</ng-template>
+<ng-template #fillerRight>
   <div fxFlex="0 0 350px" fxFlexOrder="3" fxHide.lt-lg></div>
 </ng-template>


### PR DESCRIPTION
## Description
Modification of the Article and Case Study pages layouts, where there are supposed to be three columns of information on the page. The layout is sometimes mis-aligned when there is no content to display in either the left side column or the right side column. This PR has a solution to ensure the center column will always be aligned in the middle of the page.

## Solution
Apply spacer for left or right side of 3 column layout pages. Used the existing spacer that had been added previously, but now there is one for left side (when no related docs, contacts or orgs) and one for right side (when no related items). 

## Screenshots
Article before:
![image](https://user-images.githubusercontent.com/31844476/158280860-9d2f5fe2-fa87-4bd9-8c64-2fe2a4f0874c.png)

Article after:
![image](https://user-images.githubusercontent.com/31844476/158280939-7dbe2504-1ab7-4aa1-91ac-16d927a9e24d.png)


## Testing
Manual testing using test pages in the dev environment
Article: /he-korowai-matauranga/who-to-engage
Case Study: /casestudy/testing-testsing-testing

## Have the changes been checked in the following browsers?
- [x] Chrome
- [ ] Safari
- [x] Firefox
- [x] Edge