### PR TITLE
Update feedback link in footer

### DIFF
--- a/research-hub-web/src/app/components/layout/footer/footer.component.html
+++ b/research-hub-web/src/app/components/layout/footer/footer.component.html
@@ -1,13 +1,22 @@
 <footer>
   <!-- Footer Content -->
-  <div class="footer-content" fxLayout="column" fxLayoutGap="8px" fxLayoutAlign="center center" ngClass.lt-md="site-padding-mobile">
-
-    <div style="width: 100%" fxLayoutGap="5%" fxLayout="row" fxLayout.lt-md="column">
-
+  <div
+    class="footer-content"
+    fxLayout="column"
+    fxLayoutGap="8px"
+    fxLayoutAlign="center center"
+    ngClass.lt-md="site-padding-mobile"
+  >
+    <div
+      style="width: 100%"
+      fxLayoutGap="5%"
+      fxLayout="row"
+      fxLayout.lt-md="column"
+    >
       <!-- UoA Footer Logo -->
       <div class="logo-img-container">
-        <a [href]="aucklandUniUrl" target="_blank" >
-          <img class="logo-img" src="assets/imgs/uoa-logo.svg" alt="uoa-logo">
+        <a [href]="aucklandUniUrl" target="_blank">
+          <img class="logo-img" src="assets/imgs/uoa-logo.svg" alt="uoa-logo" />
         </a>
       </div>
 
@@ -15,13 +24,22 @@
       <div fxFlex fxHide.lt-md></div>
 
       <!-- Footer Links -->
-      <div class="footer-links" fxLayout="row wrap" fxLayoutGap="2vw" fxLayoutAlign="space-between">
-        <ul class='footer-content'>
+      <div
+        class="footer-links"
+        fxLayout="row wrap"
+        fxLayoutGap="2vw"
+        fxLayoutAlign="space-between"
+      >
+        <ul class="footer-content">
           <li>
-            <a [href]="aucklandUniUrl" target="_blank">The University of Auckland</a>
+            <a [href]="aucklandUniUrl" target="_blank"
+              >The University of Auckland</a
+            >
           </li>
           <li>
-            <a [routerLink]="aboutUrl" aria-label="About the ResearchHub">About</a>
+            <a [routerLink]="aboutUrl" aria-label="About the ResearchHub"
+              >About</a
+            >
           </li>
           <li>
             <a [href]="disclaimerUrl" target="_blank">Disclaimer</a>
@@ -33,7 +51,7 @@
             <a [href]="accessibilityUrl" target="_blank">Accessibility</a>
           </li>
           <li>
-            <a [href]="feedbackUrl" target="_blank">Feedback</a>
+            <a [href]="feedbackUrl | async" target="_blank">Feedback</a>
           </li>
           <li>
             <span>Copyright © {{ getYear() }}</span>

--- a/research-hub-web/src/app/components/layout/footer/footer.component.ts
+++ b/research-hub-web/src/app/components/layout/footer/footer.component.ts
@@ -1,20 +1,26 @@
 import { Component } from '@angular/core';
+import { GetFeedbackLinkGQL } from '@app/graphql/schema';
 import { format } from 'date-fns';
+import { map } from 'rxjs';
 
 @Component({
   selector: 'app-footer',
   templateUrl: './footer.component.html',
   styleUrls: ['./footer.component.scss']
 })
-export class FooterComponent {  
+export class FooterComponent {
   public aucklandUniUrl = 'https://auckland.ac.nz';
   public aboutUrl = '/article/about';
   public disclaimerUrl = 'https://www.auckland.ac.nz/en/admin/footer-links/disclaimer.html';
   public privacyUrl = 'https://www.auckland.ac.nz/en/privacy.html';
   public accessibilityUrl = 'https://www.auckland.ac.nz/en/accessibility.html';
-  public feedbackUrl = "https://docs.google.com/forms/d/e/1FAIpQLSdSLhFgCw2uy6AZvzcK-1-UV9b_qYk6MdR0eZfM-NDwKNZyoA/viewform?usp=sf_link";
+  public feedbackUrl = this.getFeedbackLinkGQL.fetch().pipe(
+    map(result => result.data.homepageCollection?.items[0]?.feedbackLink)
+  );
 
-  constructor() { }
+  constructor(
+    private getFeedbackLinkGQL: GetFeedbackLinkGQL
+  ) { }
 
   // Get year for footer copyright
   getYear() {

--- a/research-hub-web/src/app/graphql/queries/get-feedback-link.graphql
+++ b/research-hub-web/src/app/graphql/queries/get-feedback-link.graphql
@@ -1,0 +1,7 @@
+query GetFeedbackLink {
+  homepageCollection(limit: 1) {
+    items {
+      feedbackLink
+    }
+  }
+}


### PR DESCRIPTION
## Description
This PR updates the feedback link in the footer component to point to the same link as the feedback button on the homepage

## Solution
A new graphQL query was created called GetFeedbackLink which only fetches the feedback link from the homepage entry in contentful. The feedbackUrl field in the footer component was then changed to point to this resource.

## Have the changes been checked in the following browsers?
- [x] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge