### PR TITLE
Add Contentful link checker app deployment to CI pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -151,7 +151,7 @@ pipeline {
                         echo 'Building subhub-link-checker project'
                         dir("subhub-link-checker") {
                             echo 'Installing subhub-link-checker dependencies...'
-                            sh "npm install"
+                            sh "npm ci"
                             sh "npm run build"
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,7 @@ pipeline {
         booleanParam(name: "FORCE_REDEPLOY_WEB", defaultValue: false, description: 'Force redeploy the web frontend even if there are no code changes.' )
         booleanParam(name: "FORCE_REDEPLOY_CG", defaultValue: false, description: 'Force redeploy the cer-graphql API even if there are no code changes.')
         booleanParam(name: "FORCE_REDEPLOY_SP", defaultValue: false, description: 'Force redeploy the search-proxy Lambda  even if there are no code changes.')
+        booleanParam(name: "FORCE_REDEPLOY_SLC", defaultValue: false, description: 'Force redeploy the subhub-link-checker Contentful App even if there are no code changes.')
     }
 
     agent {
@@ -108,7 +109,7 @@ pipeline {
             }
         }
 
-        stage('Build cer-graphql and search-proxy projects') {
+        stage('Build cer-graphql, subhub-link-checker and search-proxy projects') {
             stages {
                 stage('Build search-proxy') {
                     when {
@@ -138,6 +139,23 @@ pipeline {
                             sh "docker build . -t cer-graphql:latest"
                         }
                     }
+                }
+                stage('Build subhub-link-checker') {
+                    when {
+                        anyOf {
+                            changeset "**/subhub-link-checker/**/*.*"
+                            equals expected: true, actual: params.FORCE_REDEPLOY_SLC
+                        }
+                    }
+                    steps {
+                        echo 'Building subhub-link-checker project'
+                        dir("subhub-link-checker") {
+                            echo 'Installing subhub-link-checker dependencies...'
+                            sh "npm install"
+                            sh "npm run build"
+                        }
+                    }
+                    
                 }
             }
         }
@@ -184,7 +202,7 @@ pipeline {
             }
         }
 
-        stage('Deploy cer-graphql and search-proxy projects') {
+        stage('Deploy cer-graphql, search-proxy and subhub-link-checker projects') {
             parallel {
                 stage('Deploy cer-graphql') {
                     when {
@@ -224,6 +242,27 @@ pipeline {
                             }
                         }
                         echo "Deploy to ${BRANCH_NAME} complete"
+                    }
+                }
+                stage('Deploy subhub-link-checker') {
+                    when {
+                        anyOf {
+                            changeset "**/subhub-link-checker/**/*.*"
+                            equals expected: true, actual: params.FORCE_REDEPLOY_SLC
+                        }
+                    }
+                    steps {
+                        dir("subhub-link-checker") {
+                            // Grab relevant credentials
+                            withCredentials([
+                                string(credentialsId: "contentful-pat", variable: "contentfulPat"),
+                                string(credentialsId: "contentful-link-checker-app-id-${BRANCH_NAME}", variable: "contentfulSLCAppId"),
+                                string(credentialsId: "contentful-org-id", variable: "contentfulOrgId")
+                            ]) {
+                                sh "npm run upload-ci -- --organization-id ${contentful-org-id} --definition-id ${contentfulSLCAppId} --token ${contentfulPat}"
+                            }
+                            
+                        }
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -259,7 +259,7 @@ pipeline {
                                 string(credentialsId: "contentful-link-checker-app-id-${BRANCH_NAME}", variable: "contentfulSLCAppId"),
                                 string(credentialsId: "contentful-org-id", variable: "contentfulOrgId")
                             ]) {
-                                sh "npm run upload-ci -- --organization-id ${contentful-org-id} --definition-id ${contentfulSLCAppId} --token ${contentfulPat}"
+                                sh "npm run upload-ci -- --organization-id ${contentfulOrgId} --definition-id ${contentfulSLCAppId} --token ${contentfulPat}"
                             }
                             
                         }

--- a/subhub-link-checker/README.md
+++ b/subhub-link-checker/README.md
@@ -21,7 +21,7 @@ ResearchHub has three Contentful environments - `dev`, `test`, and `prod`, and `
 This assumes the Contentful environments are set up with the required app definitions. See the First time deployment section if you need to redo those steps.
 
 # Manual deployment
-If you would like to manually deploy the App (for example, if you would like to preview changes in the dev Contentful environment without ), follow these instructions.
+If you would like to manually deploy the App (for example, if you would like to preview changes in the dev Contentful environment without having to commit and push into your dev branch), follow these instructions.
 
 1. Run `npm run build` to build a new bundle.
 2. Run `npm run upload`.

--- a/subhub-link-checker/README.md
+++ b/subhub-link-checker/README.md
@@ -64,10 +64,10 @@ These instructions are for deploying to a fresh Contentful instance.
 
     Open a SubHub to verify the Internal Pages field is still editable. If it is, then the App setup is complete!
 
-4. Create a [Contentful personal access token](https://www.contentful.com/developers/docs/references/authentication/#getting-a-personal-access-token), preferably using a service account. Add 5 secrets to Jenkins credentials store, so the Jenkins CI process can refer to the values:
-* Personal Access Token: contentful-pat
-*  The App definition ID for each app definition: contentful-link-checker-app-id-dev, contentful-link-checker-app-id-test, and contentful-link-checker-app-id-prod.
-* Organisation ID: contentful-org-id
+4. Create a [Contentful personal access token](https://www.contentful.com/developers/docs/references/authentication/#getting-a-personal-access-token), preferably using a service account. Add these five secrets to Jenkins credentials store, so the Jenkins CI process can refer to the values. Read `Jenkinsfile` to see how these values are used. 
+    * Personal Access Token: `contentful-pat`
+    *  The App definition ID for each app definition: `contentful-link-checker-app-id-dev`, `contentful-link-checker-app-id-test`, and `contentful-link-checker-app-id-prod`.
+    * Organisation ID: `contentful-org-id`
 
 ## Development
 This project was bootstrapped with [Create Contentful App](https://github.com/contentful/create-contentful-app).

--- a/subhub-link-checker/README.md
+++ b/subhub-link-checker/README.md
@@ -20,7 +20,7 @@ ResearchHub has three Contentful environments - `dev`, `test`, and `prod`, and `
 
 This assumes the Contentful environments are set up with the required app definitions. See the First time deployment section if you need to redo those steps.
 
-# Manual deployment
+## Manual deployment
 If you would like to manually deploy the App (for example, if you would like to preview changes in the dev Contentful environment without having to commit and push into your dev branch), follow these instructions.
 
 1. Run `npm run build` to build a new bundle.

--- a/subhub-link-checker/README.md
+++ b/subhub-link-checker/README.md
@@ -14,11 +14,15 @@ Part of the Hub Expansion project. This is required due to SubHub routing logic 
 There are three instances of the Contentful App - one for dev, test and prod. [Read more...](https://www.contentful.com/developers/docs/extensibility/app-framework/)
 
 ## Seeing and deploying your changes
+Build and deployment for the SubHub Link Checker app are part of the Jenkins CI process. 
+
+ResearchHub has three Contentful environments - `dev`, `test`, and `prod`, and `prod` is the one content authors see. An [app definition](https://www.contentful.com/developers/docs/extensibility/app-framework/app-definition/) is set up for in three different environments, which means different versions of the link checker app can run in each environment. Deploy changes to `dev` for previewing your changes and manual testing - Contentful Apps can't be run locally. Deployment to `test` and `prod` should only be done as part of [the official release process](https://wiki.auckland.ac.nz/display/APPLCTN/Release+to+prod) and content authors need to be notified before deploying updates.
+
 This assumes the Contentful environments are set up with the required app definitions. See the First time deployment section if you need to redo those steps.
 
-ResearchHub has three Contentful environments - `dev`, `test`, and `prod`, and `prod` is the one content authors see. Use `dev` for previewing your changes and manual testing - Contentful Apps can't be run locally. Deployment to `test` and `prod` should only be done as part of [the official release process](https://wiki.auckland.ac.nz/display/APPLCTN/Release+to+prod) and content authors need to be notified before deploying updates.
+# Manual deployment
+If you would like to manually deploy the App (for example, if you would like to preview changes in the dev Contentful environment without ), follow these instructions.
 
-1. If you are deploying to `test` and `prod`, first check-in your changes to Git and merge them into `master`.
 1. Run `npm run build` to build a new bundle.
 2. Run `npm run upload`.
     1. For the bundle comment, put in the hash of Git commit you built the bundle from if applicable.
@@ -28,6 +32,7 @@ ResearchHub has three Contentful environments - `dev`, `test`, and `prod`, and `
 3. Go to Contentful to see your changes.
 
 ## First time deployment
+These instructions are for deploying to a fresh Contentful instance.
 
 1. Create three Apps on Contentful. In the `subhub-link-checker` folder, run the command:
 
@@ -58,6 +63,11 @@ ResearchHub has three Contentful environments - `dev`, `test`, and `prod`, and `
     Click on Content model tab, then the model for SubHubs (currently titled `Page > SubHub`). Find and click on the field for internal pages (currently titled `Internal Pages`). In the Appearance tab, select the SubHub Link Checker option and Save.
 
     Open a SubHub to verify the Internal Pages field is still editable. If it is, then the App setup is complete!
+
+4. Create a [Contentful personal access token](https://www.contentful.com/developers/docs/references/authentication/#getting-a-personal-access-token), preferably using a service account. Add 5 secrets to Jenkins credentials store, so the Jenkins CI process can refer to the values:
+* Personal Access Token: contentful-pat
+*  The App definition ID for each app definition: contentful-link-checker-app-id-dev, contentful-link-checker-app-id-test, and contentful-link-checker-app-id-prod.
+* Organisation ID: contentful-org-id
 
 ## Development
 This project was bootstrapped with [Create Contentful App](https://github.com/contentful/create-contentful-app).

--- a/subhub-link-checker/package-lock.json
+++ b/subhub-link-checker/package-lock.json
@@ -21,6 +21,7 @@
         "@types/node": "^16.0.2",
         "@types/react": "^17.0.14",
         "@types/react-dom": "^17.0.11",
+        "contentful-management": "^7.51.3",
         "cross-env": "^7.0.3",
         "gh-pages": "^3.1.0",
         "react": "^17.0.2",
@@ -5991,7 +5992,6 @@
       "version": "0.21.4",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
       "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.14.0"
       }
@@ -7115,7 +7115,6 @@
       "version": "7.51.3",
       "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-7.51.3.tgz",
       "integrity": "sha512-30gtIeof9wR/N8O4IyMrw1za1PGrjcc/22iblKqYlREBl0Sp5J04cutjW1Gwdcz6kxtK1YHBL0ZzjPx5ZZCROw==",
-      "peer": true,
       "dependencies": {
         "@types/json-patch": "0.0.30",
         "axios": "^0.21.4",
@@ -7132,7 +7131,6 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.11.0.tgz",
       "integrity": "sha512-GwRKR1jZMAQP/hVR929DWB5Z2lwSIM/nNcHEfDj2E0vOMhcYbqFxGKE5JaSzMdzmEtWJiamEn6VwHs/YVXVhEQ==",
-      "peer": true,
       "engines": {
         "node": ">=12.20"
       },
@@ -7144,7 +7142,6 @@
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-6.11.0.tgz",
       "integrity": "sha512-ukKxiiHdCa/izTQbA3/VUPMQB2PZW5D2KYjV9WQVOc8QjmDhu1wpEDkYxYjOrUDgT5tM7xw6umpwlifxoYe9kQ==",
-      "peer": true,
       "dependencies": {
         "fast-copy": "^2.1.0",
         "lodash.isplainobject": "^4.0.6",
@@ -24686,7 +24683,6 @@
       "version": "0.21.4",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
       "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "peer": true,
       "requires": {
         "follow-redirects": "^1.14.0"
       }
@@ -25561,7 +25557,6 @@
       "version": "7.51.3",
       "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-7.51.3.tgz",
       "integrity": "sha512-30gtIeof9wR/N8O4IyMrw1za1PGrjcc/22iblKqYlREBl0Sp5J04cutjW1Gwdcz6kxtK1YHBL0ZzjPx5ZZCROw==",
-      "peer": true,
       "requires": {
         "@types/json-patch": "0.0.30",
         "axios": "^0.21.4",
@@ -25574,8 +25569,7 @@
         "type-fest": {
           "version": "2.11.0",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.11.0.tgz",
-          "integrity": "sha512-GwRKR1jZMAQP/hVR929DWB5Z2lwSIM/nNcHEfDj2E0vOMhcYbqFxGKE5JaSzMdzmEtWJiamEn6VwHs/YVXVhEQ==",
-          "peer": true
+          "integrity": "sha512-GwRKR1jZMAQP/hVR929DWB5Z2lwSIM/nNcHEfDj2E0vOMhcYbqFxGKE5JaSzMdzmEtWJiamEn6VwHs/YVXVhEQ=="
         }
       }
     },
@@ -25583,7 +25577,6 @@
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-6.11.0.tgz",
       "integrity": "sha512-ukKxiiHdCa/izTQbA3/VUPMQB2PZW5D2KYjV9WQVOc8QjmDhu1wpEDkYxYjOrUDgT5tM7xw6umpwlifxoYe9kQ==",
-      "peer": true,
       "requires": {
         "fast-copy": "^2.1.0",
         "lodash.isplainobject": "^4.0.6",

--- a/subhub-link-checker/package.json
+++ b/subhub-link-checker/package.json
@@ -29,7 +29,7 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "upload": "contentful-app-scripts upload --bundle-dir ./build",
-    "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./build  --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
+    "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./build"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/subhub-link-checker/package.json
+++ b/subhub-link-checker/package.json
@@ -16,7 +16,7 @@
     "@types/node": "^16.0.2",
     "@types/react": "^17.0.14",
     "@types/react-dom": "^17.0.11",
-    "contentful-management": "10.3.1",
+    "contentful-management": "^7.51.3",
     "cross-env": "^7.0.3",
     "gh-pages": "^3.1.0",
     "react": "^17.0.2",

--- a/subhub-link-checker/package.json
+++ b/subhub-link-checker/package.json
@@ -16,6 +16,7 @@
     "@types/node": "^16.0.2",
     "@types/react": "^17.0.14",
     "@types/react-dom": "^17.0.11",
+    "contentful-management": "10.3.1",
     "cross-env": "^7.0.3",
     "gh-pages": "^3.1.0",
     "react": "^17.0.2",


### PR DESCRIPTION
## Description
This PR adds build and deployment for the Contentful Link Checker App to the CI pipeline, so that the App is automatically built on code changes.

## Solution
Adds build and deployment steps for the Link Checker App to the Jenkins CI pipeline, and adds relevant tokens and keys to Jenkins credentials store. Also updates documentation for Link Checker App.

## Testing
Manual testing has been done to deploy the Link Checker App to the Contentful `dev` environment.

## Have the changes been checked in the following browsers?
Browser testing is not applicable for CI pipeline changes.