### PR TITLE
Change feedback button text

### DIFF
--- a/research-hub-web/src/app/components/home/contact/contact.component.html
+++ b/research-hub-web/src/app/components/home/contact/contact.component.html
@@ -16,7 +16,7 @@
       aria-label="provide feedback on the research hub"
       class="standard-button"
     >
-      <span>Provide Feedback</span>
+      <span>Contact Us</span>
     </a>
   </div>
 </app-content-container>


### PR DESCRIPTION
## Description
Changing the feedback button text from "Provide Feedback" to "Contact Us".

## Solution
Replaced the text.

## Screenshots
![image](https://user-images.githubusercontent.com/100392333/180701230-98f1ceec-2d5c-40c6-bbd8-435e712b1fd0.png)
![2022-07-25 16_59_13-Welcome to the ResearchHub — Mozilla Firefox](https://user-images.githubusercontent.com/100392333/180701761-1133109f-0b02-4299-a81b-16a74f14fa64.png)

## Testing
All unit tests successful.

## Have the changes been checked in the following browsers?
- [x] Chrome
- [] Safari
- [x] Firefox
- [] Edge