### PR TITLE
Add capabilities navbar link

### DIFF
--- a/research-hub-web/src/app/components/layout/navbar/navbar.component.html
+++ b/research-hub-web/src/app/components/layout/navbar/navbar.component.html
@@ -31,6 +31,9 @@
     <span class="hide-small" style="flex: 1 1 auto"></span>
 
     <!--Navigation buttons-->
+    <a mat-button class="hide-small overflow-ellipsis" [routerLink]="'/researcher-development'">
+      Researcher development
+    </a>
     <a mat-button class="hide-small" [routerLink]="'/categories'">
       Categories
     </a>
@@ -42,6 +45,7 @@
     ></ng-container>
   </mat-toolbar-row>
   <mat-toolbar-row class="navbar-row-show-small">
+    <a mat-button class="overflow-ellipsis" [routerLink]="'/researcher-development'">Researcher development</a>
     <a mat-button [routerLink]="'/categories'">Categories</a>
     <a mat-button [routerLink]="'/activities'">Activities</a>
   </mat-toolbar-row>


### PR DESCRIPTION
## Description
This feature adds a new link to the navbar which leads to the Researcher development subhub

## Solution
New anchor element linking to the subhub

## Have the changes been checked in the following browsers?
- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Edge