### PR TITLE
Fix search box display on zoom

### DIFF
--- a/research-hub-web/src/partial-styles/_variables.scss
+++ b/research-hub-web/src/partial-styles/_variables.scss
@@ -24,7 +24,7 @@ $height-footer-xs: 270px;
 $padding-site: 5vw;
 $padding-site-top: 4vh;
 
-$navbar-second-row-breakpoint: 1300px;
+$navbar-second-row-breakpoint: 1100px;
 $single-column-max-width: 1100px;
 
 /**


### PR DESCRIPTION
## Description
Bug fix: Both search options disappear at 150% Zoom.

## Solution
Bug Fix: Change the Navbar second row breakpoint from 1300 pixels to 1100 pixels.

## Screenshots
Before. Search bar and search icon are invisible.
<img width="960" alt="2023-03-27 14_30_24-" src="https://user-images.githubusercontent.com/100392333/227819889-a2bdcdc7-42ec-4c09-b37f-9bb4814a5c99.png">

## Have the changes been checked in the following browsers?
- [x] Chrome
- [ ] Safari
- [x] Firefox
- [x] Edge