### PR TITLE
Fix failed start up due to Contentful type changes

### DIFF
--- a/cer-graphql/index.ts
+++ b/cer-graphql/index.ts
@@ -1,8 +1,7 @@
 import {
   DocumentNode,
   GraphQLResolveInfo,
-  GraphQLSchema,
-  printSchema
+  GraphQLSchema
 } from "graphql";
 import fetch from "cross-fetch";
 import { validateUnauthenticatedQuery } from "./validateUnauthenticatedQuery";

--- a/cer-graphql/index.ts
+++ b/cer-graphql/index.ts
@@ -104,10 +104,10 @@ async function getRemoteSchema(remoteUri: string) {
   }
 }
 /**
- * Given schema for Hub content, returns names for
+ * Given schema for Hub content, returns resolver names for
  * types that require authentication resolvers.
 * @param schema GraphQL schema for Hub content
- * @returns Array of names of types that should be protected as strings.
+ * @returns Array of resolver names for types that should be protected.
  */
 function getProtectedTypes(schema: GraphQLSchema) {
   const typeMap = schema.getTypeMap();

--- a/cer-graphql/index.ts
+++ b/cer-graphql/index.ts
@@ -1,7 +1,8 @@
 import {
   DocumentNode,
   GraphQLResolveInfo,
-  GraphQLSchema
+  GraphQLSchema,
+  printSchema
 } from "graphql";
 import fetch from "cross-fetch";
 import { validateUnauthenticatedQuery } from "./validateUnauthenticatedQuery";
@@ -103,19 +104,37 @@ async function getRemoteSchema(remoteUri: string) {
     throw new Error("Unable to load remote schema.");
   }
 }
+/**
+ * Given schema for Hub content, returns names for
+ * types that require authentication resolvers.
+* @param schema GraphQL schema for Hub content
+ * @returns Array of names of types that should be protected as strings.
+ */
 function getProtectedTypes(schema: GraphQLSchema) {
   const typeMap = schema.getTypeMap();
-
   return Object.keys(typeMap)
-    .filter(x => x.includes('Filter')) // Get all the filters
-    .filter(x => !x.startsWith('cf')) // Filter out Contentful's special cf* filters
-    .filter(y => { // Filter by those with an ssoProtected field
-      const type = typeMap[y];
-      // First check this type has its own nested fields, before seeing if it has a ssoProtected field.
-      return "getFields" in type && type.getFields()["ssoProtected"];
+    .filter(typeName => { 
+      const type = typeMap[typeName];
+      // Filters don't need resolvers.
+      if (typeName.includes("Filter")){
+        return false;
+      }
+      // If the type is a primitive, then it doesn't need protection.
+      if (!("getFields" in type)) {
+        return false;
+      } else {
+        //  If a content type has a "contentfulMetadata" field,
+        // it is a type defined by us and not a Contentful built-in type.
+        // See https://www.contentful.com/developers/docs/references/graphql/#/reference/schema-generation/contentfulmetadata-field
+        //  
+        // We then check if it has a ssoProtected field, which we use
+        // to flag authenticated content.
+        const fields = type.getFields();
+        return fields["contentfulMetadata"] && fields["ssoProtected"];
+      }
     })
-    .flatMap(z => [z.replace('Filter', ''), z.replace('Filter', 'Collection')]) // Replace 'xfilter' with 'x' and 'xCollection'
-    .map(a => a[0].toLowerCase() + a.substring(1)); // Make first char lower case
+    // Make first char lower case for resolver convention.
+    .map(a => a[0].toLowerCase() + a.substring(1)); 
 }
 
 export async function createServer (config: CerGraphqlServerConfig) {

--- a/cer-graphql/index.ts
+++ b/cer-graphql/index.ts
@@ -111,7 +111,7 @@ async function getRemoteSchema(remoteUri: string) {
  */
 function getProtectedTypes(schema: GraphQLSchema) {
   const typeMap = schema.getTypeMap();
-  return Object.keys(typeMap)
+  const itemResolvers = Object.keys(typeMap)
     .filter(typeName => { 
       const type = typeMap[typeName];
       // Filters don't need resolvers.
@@ -134,6 +134,9 @@ function getProtectedTypes(schema: GraphQLSchema) {
     })
     // Make first char lower case for resolver convention.
     .map(a => a[0].toLowerCase() + a.substring(1)); 
+    // Also protect the collection queries for each type
+    const collectionResolvers = itemResolvers.map(name => name + "Collection");
+    return itemResolvers.concat(collectionResolvers)    
 }
 
 export async function createServer (config: CerGraphqlServerConfig) {


### PR DESCRIPTION
## Description
cer-graphql was not able to launch since at least a week ago. Error was "Query.featuredItemsItems defined in resolvers, but not in schemas"
The issue seems to be a possible change in the output of Contentful's GraphQL API, particularly for introspection query. We use the GraphQL schema and the list of types to determine which content types require a custom authentication resolver (see `getProtectedTypes()`). The function would filter for types with "Filter" in it, then construct a list of resolver names based on types that have an ssoProtected field in it. The constructed names were made on the assumption that all "xFilter" types have a corresponding "x" type, but [new(?) types seem to not match this pattern](https://www.contentful.com/developers/docs/references/graphql/#/reference/schema-generation/one-to-many-multi-type-relationships) for linked items. The corresponding type name for them is "xItem". This results in the error because the generated resolver name does not match any queries.
## Solution
Rewrote the `getProtectedTypes` function to iterate through all types. Filter for types that have an ssoProtected field and has contentfulMetadata field (though perhaps only checking for ssoProtected field is needed). Also add their corresponding collection queries. The embedded types are not included in the filtered list.

## Screenshots
<!--- Add before and after screenshots of the UI if applicable -->

## Testing
Existing tests should pick up any problems.

## Have the changes been checked in the following browsers?
- [x] Chrome
- [ ] Safari
- [x] Firefox
- [ ] Edge