### PR TITLE
RSM-4489 Add Process page type to query

### DIFF
--- a/research-hub-web/src/app/graphql/queries/all-subhub-child-pages-slugs.query.graphql
+++ b/research-hub-web/src/app/graphql/queries/all-subhub-child-pages-slugs.query.graphql
@@ -32,6 +32,9 @@ query GetAllSubHubChildPagesSlugs {
                     ...on SubHub {
                         slug
                     }
+                    ...on Process {
+                        slug
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Description
Process page type is not properly mapping to the URL or breadcrumb when added as an internal page to a SubHub 
Root cause: Process page type was not included in GraphQL query (GetAllSubHubChildPagesSlugs) used to build breadcrumbs

## Solution
Added Process page type to the query following the same structure as other page types

## Screenshots
Process page now shows parent SubHub in the breadcrumb component 
<img width="631" height="120" alt="image" src="https://github.com/user-attachments/assets/31d26bf8-8bd3-46db-b4fa-9fdd134324bb" />

## Testing
<!--- Describe unit or e2e tests if they were required for this feature/fix -->

## Have the changes been checked in the following browsers?
- [x] Chrome
- [ ]  Safari
- [x] Firefox
- [x] Edge