### PR TITLE
Rc2.8.11

### DIFF
--- a/cer-graphql/package.json
+++ b/cer-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cer-graphql",
-  "version": "2.8.10",
+  "version": "2.8.11",
   "description": "A GraphQL server used to proxy and authorise requests to external data sources.",
   "main": "build/index.js",
   "scripts": {

--- a/hub-search-proxy/package.json
+++ b/hub-search-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hub-search-proxy",
-  "version": "2.8.10",
+  "version": "2.8.11",
   "description": "Serverless Framework Lambda functions to interact with AWS ElasticSearch Service.",
   "main": "handler.js",
   "scripts": {

--- a/research-hub-web/package.json
+++ b/research-hub-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "research-hub-web",
-  "version": "2.8.10",
+  "version": "2.8.11",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/research-hub-web/src/app/graphql/queries/all-subhub-child-pages-slugs.query.graphql
+++ b/research-hub-web/src/app/graphql/queries/all-subhub-child-pages-slugs.query.graphql
@@ -32,6 +32,9 @@ query GetAllSubHubChildPagesSlugs {
                     ...on SubHub {
                         slug
                     }
+                    ...on Process {
+                        slug
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Description
Process page was not correctly mapping parent SubHub URL to breadcrumb component.

## Solution
Add Process page type to GetAllSubHubChildPagesSlugs query.

## Screenshots
<!--- Add before and after screenshots of the UI if applicable -->

## Testing
<!--- Describe unit or e2e tests if they were required for this feature/fix -->

## Have the changes been checked in the following browsers?
- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge